### PR TITLE
Change default host to empty string

### DIFF
--- a/scratch/scratch.py
+++ b/scratch/scratch.py
@@ -14,7 +14,7 @@ class Scratch(object):
 
     msg_types = set(['broadcast', 'sensor-update'])
 
-    def __init__(self, host='localhost', port=42001):
+    def __init__(self, host='', port=42001):
 	self.host = host
 	self.port = port
 	self.socket = None


### PR DESCRIPTION
Using 'localhost' as the default host was throwing connection refused on Linux running Python 2.7.8.
